### PR TITLE
Fix typo

### DIFF
--- a/synap_convert.py
+++ b/synap_convert.py
@@ -86,7 +86,7 @@ def main():
     if tools_dir is None:
         # Assume the directory layout of the public toolkit directory
         synap_dir = pathlib.Path(__file__).parent.parent.absolute()
-        tools_dir = os.path.join(synap_dir, "toolkit-prebuilt")
+        tools_dir = os.path.join(synap_dir, "toolkit-prebuilts")
     if not os.path.isdir(tools_dir):
         raise ConversionError(f"\n\nCan't find directory for toolkit prebuilts: {tools_dir}\n"
                               "You can use the '--tools-dir' option to set the toolkit prebuilts path "


### PR DESCRIPTION
Fix default path to match repo name [`synaptics-synap/toolkit-prebuilts`](https://github.com/synaptics-synap/toolkit-prebuilts)